### PR TITLE
Fix the TRIM command only erasing one segment

### DIFF
--- a/ftl/page/page-core.c
+++ b/ftl/page/page-core.c
@@ -49,35 +49,6 @@ static size_t page_ftl_get_free_pages(struct page_ftl *pgftl)
 }
 
 /**
- * @brief do garbage collection from the gc list
- *
- * @param pgftl pointer of the page ftl
- * @param request pointer of the request
- *
- * @return number of erased segments
- */
-static ssize_t page_ftl_gc_from_list(struct page_ftl *pgftl,
-				     struct device_request *request)
-{
-	ssize_t ret = 0;
-	size_t nr_segments, nr_gc_segments, idx;
-	nr_segments = device_get_nr_segments(pgftl->dev);
-	nr_gc_segments = (size_t)((double)nr_segments * PAGE_FTL_GC_RATIO);
-	for (idx = 0; (ssize_t)idx >= 0 && idx < nr_gc_segments; idx++) {
-		ret = page_ftl_submit_request(pgftl, request);
-		if (ret) {
-			pr_err("garbage collection from list failed\n");
-			return ret;
-		}
-		if (pgftl->gc_list == NULL) {
-			break;
-		}
-	}
-	ret = (ssize_t)idx;
-	return ret;
-}
-
-/**
  * @brief do garbage collection thread
  *
  * @param data containing the pointer of the page ftl structure

--- a/ftl/page/page-gc.c
+++ b/ftl/page/page-gc.c
@@ -61,7 +61,7 @@ static struct page_ftl_segment *page_ftl_pick_gc_target(struct page_ftl *pgftl)
 	}
 	pgftl->gc_list = g_list_sort(pgftl->gc_list, page_ftl_gc_list_cmp);
 	segment = (struct page_ftl_segment *)pgftl->gc_list->data;
-	pr_debug("gc target: %zu (valid: %ld) => %p\n",
+	pr_debug("gc target: %zu (valid: %d) => %p\n",
 		 page_ftl_get_segment_number(pgftl, (uintptr_t)segment),
 		 g_atomic_int_get(&segment->nr_valid_pages), segment);
 	pgftl->gc_list = g_list_remove(pgftl->gc_list, segment);

--- a/ftl/page/page-gc.c
+++ b/ftl/page/page-gc.c
@@ -292,3 +292,32 @@ ssize_t page_ftl_do_gc(struct page_ftl *pgftl)
 
 	return 0;
 }
+
+/**
+ * @brief do garbage collection from the gc list
+ *
+ * @param pgftl pointer of the page ftl
+ * @param request pointer of the request
+ *
+ * @return number of erased segments
+ */
+ssize_t page_ftl_gc_from_list(struct page_ftl *pgftl,
+			      struct device_request *request)
+{
+	ssize_t ret = 0;
+	size_t nr_segments, nr_gc_segments, idx;
+	nr_segments = device_get_nr_segments(pgftl->dev);
+	nr_gc_segments = (size_t)((double)nr_segments * PAGE_FTL_GC_RATIO);
+	for (idx = 0; (ssize_t)idx >= 0 && idx < nr_gc_segments; idx++) {
+		ret = page_ftl_submit_request(pgftl, request);
+		if (ret) {
+			pr_err("garbage collection from list failed\n");
+			return ret;
+		}
+		if (pgftl->gc_list == NULL) {
+			break;
+		}
+	}
+	ret = (ssize_t)idx;
+	return ret;
+}

--- a/ftl/page/page-interface.c
+++ b/ftl/page/page-interface.c
@@ -314,7 +314,7 @@ static int page_ftl_ioctl_interface(struct flash_device *flash,
 	switch (request) {
 	case PAGE_FTL_IOCTL_TRIM:
 		device_rq->flag = DEVICE_ERASE;
-		ret = (int)page_ftl_submit_request(pgftl, device_rq);
+		ret = (int)page_ftl_gc_from_list(pgftl, device_rq);
 		break;
 	default:
 		pr_err("invalid command requested(commands: %u)\n", request);

--- a/include/page.h
+++ b/include/page.h
@@ -90,6 +90,7 @@ int page_ftl_segment_data_init(struct page_ftl *, struct page_ftl_segment *);
 
 /* page-gc.c */
 ssize_t page_ftl_do_gc(struct page_ftl *);
+ssize_t page_ftl_gc_from_list(struct page_ftl *, struct device_request *);
 
 static inline size_t page_ftl_get_map_size(struct page_ftl *pgftl)
 {


### PR DESCRIPTION
The TRIM command only does to erase one segment because it calls the `page_ftl_do_gc` function. That function erases only one segment.

So, I adopt the `page_ftl_gc_from_list` function to remove the number of segments. The number of segments that will be removed is equal to the defined threshold.