### PR TITLE
Do garbage collection to all dirty segments

### DIFF
--- a/ftl/page/page-core.c
+++ b/ftl/page/page-core.c
@@ -25,30 +25,6 @@
 static int is_gc_thread_exit;
 
 /**
- * @brief get number of invalid pages in the ftl
- *
- * @param pgftl pointer of the page ftl structure
- *
- * @return number of the invalid pages
- */
-static size_t page_ftl_get_free_pages(struct page_ftl *pgftl)
-{
-	size_t free_pages;
-	size_t nr_segments, segnum;
-	struct page_ftl_segment *segment;
-
-	nr_segments = device_get_nr_segments(pgftl->dev);
-
-	free_pages = 0;
-	for (segnum = 0; segnum < nr_segments; segnum++) {
-		segment = &pgftl->segments[segnum];
-		assert(NULL != segment);
-		free_pages += (size_t)g_atomic_int_get(&segment->nr_free_pages);
-	}
-	return free_pages;
-}
-
-/**
  * @brief do garbage collection thread
  *
  * @param data containing the pointer of the page ftl structure
@@ -86,7 +62,7 @@ static void *page_ftl_gc_thread(void *data)
 		    (double)total_pages * PAGE_FTL_GC_THRESHOLD) {
 			continue;
 		}
-		ret = page_ftl_gc_from_list(pgftl, &request);
+		ret = page_ftl_gc_from_list(pgftl, &request, PAGE_FTL_GC_RATIO);
 		if (ret < 0) {
 			pr_err("critical garbage collection error detected (errno: %zd)\n",
 			       ret);

--- a/ftl/page/page-gc.c
+++ b/ftl/page/page-gc.c
@@ -298,16 +298,17 @@ ssize_t page_ftl_do_gc(struct page_ftl *pgftl)
  *
  * @param pgftl pointer of the page ftl
  * @param request pointer of the request
+ * @param gc_ratio ratio for garbage collecting targets
  *
  * @return number of erased segments
  */
 ssize_t page_ftl_gc_from_list(struct page_ftl *pgftl,
-			      struct device_request *request)
+			      struct device_request *request, double gc_ratio)
 {
 	ssize_t ret = 0;
 	size_t nr_segments, nr_gc_segments, idx;
 	nr_segments = device_get_nr_segments(pgftl->dev);
-	nr_gc_segments = (size_t)((double)nr_segments * PAGE_FTL_GC_RATIO);
+	nr_gc_segments = (size_t)((double)nr_segments * gc_ratio);
 	for (idx = 0; (ssize_t)idx >= 0 && idx < nr_gc_segments; idx++) {
 		ret = page_ftl_submit_request(pgftl, request);
 		if (ret) {

--- a/ftl/page/page-interface.c
+++ b/ftl/page/page-interface.c
@@ -314,7 +314,8 @@ static int page_ftl_ioctl_interface(struct flash_device *flash,
 	switch (request) {
 	case PAGE_FTL_IOCTL_TRIM:
 		device_rq->flag = DEVICE_ERASE;
-		ret = (int)page_ftl_gc_from_list(pgftl, device_rq);
+		ret = (int)page_ftl_gc_from_list(pgftl, device_rq,
+						 PAGE_FTL_GC_ALL);
 		break;
 	default:
 		pr_err("invalid command requested(commands: %u)\n", request);

--- a/include/page.h
+++ b/include/page.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <pthread.h>
 
+#include <assert.h>
 #include <limits.h>
 #include <unistd.h>
 
@@ -24,6 +25,7 @@
 #define PAGE_FTL_GC_RATIO                                                      \
 	((double)10 /                                                          \
 	 100) /**< maximum the number of segments garbage collected */
+#define PAGE_FTL_GC_ALL ((double)1) /**< collect all dirty segments */
 #define PAGE_FTL_GC_THRESHOLD                                                  \
 	((double)20 /                                                          \
 	 100) /**< gc triggered when number of the free pages under threshold */
@@ -90,7 +92,8 @@ int page_ftl_segment_data_init(struct page_ftl *, struct page_ftl_segment *);
 
 /* page-gc.c */
 ssize_t page_ftl_do_gc(struct page_ftl *);
-ssize_t page_ftl_gc_from_list(struct page_ftl *, struct device_request *);
+ssize_t page_ftl_gc_from_list(struct page_ftl *, struct device_request *,
+			      double gc_ratio);
 
 static inline size_t page_ftl_get_map_size(struct page_ftl *pgftl)
 {
@@ -114,5 +117,22 @@ static inline size_t page_ftl_get_segment_number(struct page_ftl *pgftl,
 {
 	return (segment - (uintptr_t)pgftl->segments) /
 	       sizeof(struct page_ftl_segment);
+}
+
+static inline size_t page_ftl_get_free_pages(struct page_ftl *pgftl)
+{
+	size_t free_pages;
+	size_t nr_segments, segnum;
+	struct page_ftl_segment *segment;
+
+	nr_segments = device_get_nr_segments(pgftl->dev);
+
+	free_pages = 0;
+	for (segnum = 0; segnum < nr_segments; segnum++) {
+		segment = &pgftl->segments[segnum];
+		assert(NULL != segment);
+		free_pages += (size_t)g_atomic_int_get(&segment->nr_free_pages);
+	}
+	return free_pages;
 }
 #endif


### PR DESCRIPTION
About #34 issue, I thought that the number of segments that will be collected might need to collect all.

So, I added an adjustable parameter to the `page_ftl_gc_from_list` function and created the `PAGE_FTL_GC_ALL` flag to execute collecting all.