### PR TITLE
Remove the unnecessary part in Ramdisk

### DIFF
--- a/device/ramdisk/ramdisk.c
+++ b/device/ramdisk/ramdisk.c
@@ -88,9 +88,6 @@ int ramdisk_open(struct device *dev, const char *name, int flags)
 	}
 	memset(dev->badseg_bitmap, 0,
 	       (size_t)BITS_TO_UINT64_ALIGN(nr_segments));
-	for (uint64_t i = 0; i < 10; i++) {
-		set_bit(dev->badseg_bitmap, i);
-	}
 	return ret;
 exception:
 	ramdisk_close(dev);


### PR DESCRIPTION
I found that the unnecessary part exists in the Ramdisk module. It was for verifying the working of Ramdisk with bad segments. 

However, it might create problems in evaluating the performance and verifying the behavior. Therefore, I decided to remove this logic.